### PR TITLE
修复：兼容 Touhma 版 Galactic Scale 2

### DIFF
--- a/ProjectOrbitalRing.csproj
+++ b/ProjectOrbitalRing.csproj
@@ -263,6 +263,7 @@
     <Compile Include="src\Utils\JsonHelper.cs" />
     <Compile Include="src\Utils\KvpDeconstruct.cs" />
     <Compile Include="src\Utils\MutliPlayerPacket.cs" />
+    <Compile Include="src\Utils\PlanetThemeUtils.cs" />
     <Compile Include="src\Utils\ProtoID.cs" />
     <Compile Include="src\Utils\RandomUtils.cs" />
     <Compile Include="src\Utils\TextureHelper.cs" />

--- a/src/Compatibility/GalacticScale.cs
+++ b/src/Compatibility/GalacticScale.cs
@@ -76,28 +76,34 @@ namespace ProjectOrbitalRing.Compatibility
             MethodInfo OnPlanetDataSet7Prefix =
                 AccessTools.Method(assembly.GetType("GalacticScale.PatchOnUIPlanetDetail"), "OnPlanetDataSet7Prefix");
 
-            HarmonyPatch.Patch(OnPlanetDataSet7Prefix, null, null,
-                new HarmonyMethod(typeof(GalacticScale), nameof(OnPlanetDataSet_Transpiler)));
+            if (OnPlanetDataSet7Prefix != null)
+            {
+                HarmonyPatch.Patch(OnPlanetDataSet7Prefix, null, null,
+                    new HarmonyMethod(typeof(GalacticScale), nameof(OnPlanetDataSet_Transpiler)));
 
-            //HarmonyPatch.Patch(OnPlanetDataSet7Prefix, null, null,
-            //    new HarmonyMethod(typeof(PlanetGasPatches), nameof(PlanetGasPatches.OnDataSet_ChangeWaterId_Transpiler)));
+                //HarmonyPatch.Patch(OnPlanetDataSet7Prefix, null, null,
+                //    new HarmonyMethod(typeof(PlanetGasPatches), nameof(PlanetGasPatches.OnDataSet_ChangeWaterId_Transpiler)));
 
-            HarmonyPatch.Patch(OnPlanetDataSet7Prefix, null, null,
-                new HarmonyMethod(typeof(GalacticScale), nameof(OnPlanetDataSet_ChangeVeinData_Transpiler)));
+                HarmonyPatch.Patch(OnPlanetDataSet7Prefix, null, null,
+                    new HarmonyMethod(typeof(GalacticScale), nameof(OnPlanetDataSet_ChangeVeinData_Transpiler)));
+            }
 
             MethodInfo OnStarDataSet2 = AccessTools.Method(assembly.GetType("GalacticScale.PatchOnUIStarDetail"), "OnStarDataSet2");
 
-            //HarmonyPatch.Patch(OnStarDataSet2, null, null,
-            //    new HarmonyMethod(typeof(PlanetGasPatches), nameof(PlanetGasPatches.OnDataSet_ChangeWaterId_Transpiler)));
+            if (OnStarDataSet2 != null)
+            {
+                //HarmonyPatch.Patch(OnStarDataSet2, null, null,
+                //    new HarmonyMethod(typeof(PlanetGasPatches), nameof(PlanetGasPatches.OnDataSet_ChangeWaterId_Transpiler)));
 
-            //HarmonyPatch.Patch(OnStarDataSet2, null, null,
-            //    new HarmonyMethod(typeof(PlanetGasPatches), nameof(PlanetGasPatches.PlanetGen_SetPlanetTheme_Transpiler)));
+                //HarmonyPatch.Patch(OnStarDataSet2, null, null,
+                //    new HarmonyMethod(typeof(PlanetGasPatches), nameof(PlanetGasPatches.PlanetGen_SetPlanetTheme_Transpiler)));
 
-            //HarmonyPatch.Patch(OnStarDataSet2, null, null,
-            //    new HarmonyMethod(typeof(PlanetGasPatches), nameof(PlanetGasPatches.OnStarDataSet_Transpiler)));
+                //HarmonyPatch.Patch(OnStarDataSet2, null, null,
+                //    new HarmonyMethod(typeof(PlanetGasPatches), nameof(PlanetGasPatches.OnStarDataSet_Transpiler)));
 
-            HarmonyPatch.Patch(OnStarDataSet2, null, null,
-                new HarmonyMethod(typeof(GalacticScale), nameof(OnStarDataSet_ChangeVeinData_Transpiler)));
+                HarmonyPatch.Patch(OnStarDataSet2, null, null,
+                    new HarmonyMethod(typeof(GalacticScale), nameof(OnStarDataSet_ChangeVeinData_Transpiler)));
+            }
         }
 
         public static IEnumerable<CodeInstruction> SetPlanetTheme_Transpiler(IEnumerable<CodeInstruction> instructions)

--- a/src/Patches/Logic/FelTreeObjects.cs
+++ b/src/Patches/Logic/FelTreeObjects.cs
@@ -111,7 +111,8 @@ namespace ProjectOrbitalRing.Patches.Logic
                     LDB.items.Select(ProtoID.I大型神经网络) == null || LDB.items.Select(ProtoID.I种子) == null) {
                     return;
                 }
-                if (__instance.planet.theme == 8 || __instance.planet.theme == 25) {
+                int vanillaTheme = PlanetThemeUtils.GetVanillaThemeId(__instance.planet);
+                if (vanillaTheme == 8 || vanillaTheme == 25) {
                     //0.0500概率获得高速生长菌群
                     if (random > 0.00001 && random <= 0.05001) {
                         itemProtoID = ProtoID.I高速生长菌群;
@@ -123,7 +124,7 @@ namespace ProjectOrbitalRing.Patches.Logic
                         itemProtoID = ProtoID.I种子;
                         itemCount = randomCount5;
                     }
-                } else if (__instance.planet.theme == 14) {
+                } else if (vanillaTheme == 14) {
                     if (random > 0.00001 && random <= 0.30001) {
                         itemProtoID = ProtoID.I菌丝母株;
                         itemCount = 1;
@@ -158,18 +159,19 @@ namespace ProjectOrbitalRing.Patches.Logic
                         itemCount = 1;
                     }
                 } else {
-                    if (__instance.planet.theme == 17) {
+                    int vanillaTheme2 = PlanetThemeUtils.GetVanillaThemeId(__instance.planet);
+                    if (vanillaTheme2 == 17) {
                         //0.20概率获得未知射线遗留样本
                         if (random > 0.00001 && random <= 0.4001) {
                             itemProtoID = 6216;
                             itemCount = 1;
                         }
-                    } else if (__instance.planet.theme == 6) {
+                    } else if (vanillaTheme2 == 6) {
                         if (random > 0.00001 && random <= 0.3001) {
                             itemProtoID = ProtoID.I黑盒;
                             itemCount = 1;
                         }
-                    } else if (__instance.planet.theme == 15 || __instance.planet.theme == 22) {
+                    } else if (vanillaTheme2 == 15 || vanillaTheme2 == 22) {
                         if (random > 0.00001 && random <= 0.4001) {
                             itemProtoID = ProtoID.I文明遗物;
                             itemCount = 1;

--- a/src/Patches/Logic/Module/AssemblerModule.cs
+++ b/src/Patches/Logic/Module/AssemblerModule.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection.Emit;
 using HarmonyLib;
+using ProjectOrbitalRing.Utils;
 using ProjectOrbitalRing.Patches.Logic.OrbitalRing;
 using static ProjectOrbitalRing.ProjectOrbitalRing;
 using static ProjectOrbitalRing.Patches.UI.UIAssemblerWindowPatch;
@@ -398,7 +399,8 @@ namespace ProjectOrbitalRing.Patches.Logic.AssemblerModule
 
 
                 int PowerRatio = 1000;
-                if (factory.planet.theme == 7 || factory.planet.theme == 10 || factory.planet.theme == 20 || factory.planet.theme == 24) {
+                int vanillaTheme = PlanetThemeUtils.GetVanillaThemeId(factory.planet);
+                if (vanillaTheme == 7 || vanillaTheme == 10 || vanillaTheme == 20 || vanillaTheme == 24) {
                     PowerRatio = 500;
                 }
                 var planetOrbitalRingData = OrbitalStationManager.Instance.GetPlanetOrbitalRingData(factory.planetId);

--- a/src/Patches/Logic/OrbitalRing/OrbitalBuild.cs
+++ b/src/Patches/Logic/OrbitalRing/OrbitalBuild.cs
@@ -10,6 +10,18 @@ namespace ProjectOrbitalRing.Patches.Logic.OrbitalRing
 {
     internal class OrbitalBuild
     {
+        private static readonly HashSet<string> LoggedThemeCheckFailures = new HashSet<string>();
+
+        private static void LogThemeCheckFailure(PlanetData planet, int previewItem, int resolvedTheme, string reason)
+        {
+            if (planet == null) return;
+
+            string key = planet.id + ":" + previewItem + ":" + resolvedTheme + ":" + reason;
+            if (!LoggedThemeCheckFailures.Add(key)) return;
+
+            global::ProjectOrbitalRing.ProjectOrbitalRing.LogWarning($"[{reason}] itemId={previewItem}, {PlanetThemeUtils.GetThemeDebugInfo(planet)}");
+        }
+
         private static bool IsBuildingItemIdisOrbitalCore(int itemId)
         {
             switch (itemId) {
@@ -308,13 +320,17 @@ namespace ProjectOrbitalRing.Patches.Logic.OrbitalRing
 
                 if (previewItem == 2311) {
                     // 电磁轨道弹射器
-                    if (__instance.planet.theme != 11) { // 贫瘠荒漠
+                    if (PlanetThemeUtils.GetVanillaThemeId(__instance.planet) != 11) { // 贫瘠荒漠
+                        LogThemeCheckFailure(__instance.planet, previewItem, PlanetThemeUtils.GetVanillaThemeId(__instance.planet), "电磁轨道弹射器建造条件失败");
                         buildPreview.condition = (EBuildCondition)96;
                         __instance.AddErrorMessage((EBuildCondition)96, buildPreview);
                     }
                 }
                 if (previewItem == ProtoID.I低温工厂) {
-                    if (!(__instance.planet.theme == 7 || __instance.planet.theme == 10 || __instance.planet.theme == 20 || __instance.planet.theme == 24 )) { // 冰星
+                    int vanillaTheme = PlanetThemeUtils.GetVanillaThemeId(__instance.planet);
+                    if (!(vanillaTheme == 7 || vanillaTheme == 10 || vanillaTheme == 20 || vanillaTheme == 24))
+                    { // 冰星
+                        LogThemeCheckFailure(__instance.planet, previewItem, vanillaTheme, "低温工厂建造条件失败");
                         buildPreview.condition = (EBuildCondition)94;
                         __instance.AddErrorMessage((EBuildCondition)94, buildPreview);
                     }
@@ -453,14 +469,18 @@ namespace ProjectOrbitalRing.Patches.Logic.OrbitalRing
 
                 if (previewItem == 2311) {
                     // 电磁轨道弹射器
-                    if (__instance.planet.theme != 11) { // 贫瘠荒漠
+                    if (PlanetThemeUtils.GetVanillaThemeId(__instance.planet) != 11) { // 贫瘠荒漠
+                        LogThemeCheckFailure(__instance.planet, previewItem, PlanetThemeUtils.GetVanillaThemeId(__instance.planet), "电磁轨道弹射器建造条件失败");
                         buildPreview.condition = (EBuildCondition)96;
                         __result = false;
                         return false;
                     }
                 }
                 if (previewItem == ProtoID.I低温工厂) {
-                    if (!(__instance.planet.theme == 7 || __instance.planet.theme == 10 || __instance.planet.theme == 20 || __instance.planet.theme == 24)) { // 冰星
+                    int vanillaTheme = PlanetThemeUtils.GetVanillaThemeId(__instance.planet);
+                    if (!(vanillaTheme == 7 || vanillaTheme == 10 || vanillaTheme == 20 || vanillaTheme == 24))
+                    { // 冰星
+                        LogThemeCheckFailure(__instance.planet, previewItem, vanillaTheme, "低温工厂建造条件失败");
                         buildPreview.condition = (EBuildCondition)94;
                         __result = false;
                         return false;

--- a/src/Patches/Logic/PlanetFocus/MoonPatch.cs
+++ b/src/Patches/Logic/PlanetFocus/MoonPatch.cs
@@ -1,6 +1,7 @@
 ﻿using HarmonyLib;
 using ProjectOrbitalRing.Patches.Logic.AssemblerModule;
 using ProjectOrbitalRing.Patches.UI;
+using ProjectOrbitalRing.Utils;
 using System;
 using System.Collections;
 using System.Collections.Concurrent;
@@ -153,7 +154,7 @@ namespace ProjectOrbitalRing.Patches.Logic.PlanetFocus
                 if (assemblerId > 0) {
                     AssemblerComponent assembler = __instance.factorySystem.assemblerPool[assemblerId];
                     // 贫瘠荒漠特质，熔炉产物自带增产
-                    if (__instance.planet.theme == 11) {
+                    if (PlanetThemeUtils.GetVanillaThemeId(__instance.planet) == 11) {
                         if ((assembler.recipeType == ERecipeType.Smelt || assembler.recipeType == (ERecipeType)11) && assembler.speed < 40000) {
                             if (__result != 0) {
                                 inc = 4;
@@ -193,7 +194,7 @@ namespace ProjectOrbitalRing.Patches.Logic.PlanetFocus
                                 return;
                             }
                             // 贫瘠荒漠特质，熔炉产物自带增产
-                            if (__instance.planet.theme == 11) {
+                            if (PlanetThemeUtils.GetVanillaThemeId(__instance.planet) == 11) {
                                 if ((ptr.recipeType == ERecipeType.Smelt || ptr.recipeType == (ERecipeType)11) && ptr.speed < 40000) {
                                     if (__result != 0) {
                                         inc = 4;

--- a/src/Patches/Logic/PlanetFocus/WaterWorldPatch.cs
+++ b/src/Patches/Logic/PlanetFocus/WaterWorldPatch.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using ProjectOrbitalRing.Utils;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -11,7 +12,7 @@ namespace ProjectOrbitalRing.Patches.Logic.PlanetFocus
         private static readonly int[] UseWaterRecipes = { 5, 16, 24, 64, 403, 404, 512, 513, 517, 518, 702, 708, 711, 714, 797, 813, 836 };
         public static void SetAssmeblerWaterFull(ref AssemblerComponent __instance, PlanetFactory factory)
         {
-            if (factory.planet.theme != 16) {
+            if (PlanetThemeUtils.GetVanillaThemeId(factory.planet) != 16) {
                 return;
             }
             for (int i = 0; i < UseWaterRecipes.Length; i++) {

--- a/src/Patches/UI/PlanetFocus/UIPlanetDetailExpand.cs
+++ b/src/Patches/UI/PlanetFocus/UIPlanetDetailExpand.cs
@@ -1,4 +1,5 @@
-﻿using HarmonyLib;
+﻿using System.Collections.Generic;
+using HarmonyLib;
 using ProjectOrbitalRing.Patches.UI.Utils;
 using ProjectOrbitalRing.Utils;
 
@@ -8,6 +9,18 @@ namespace ProjectOrbitalRing.Patches.UI.PlanetFocus
 {
     public static class UIPlanetDetailExpand
     {
+        private static readonly HashSet<int> LoggedDefaultFocusPlanetIds = new HashSet<int>();
+
+        private static void LogDefaultFocus(PlanetData planet)
+        {
+            if (planet == null) return;
+            if (!LoggedDefaultFocusPlanetIds.Add(planet.id)) return;
+
+            global::ProjectOrbitalRing.ProjectOrbitalRing.LogWarning(
+                $"[星球特质走默认分支 FocusId=6534] {PlanetThemeUtils.GetThemeDebugInfo(planet)}"
+            );
+        }
+
         private static UIButton _planetFocusBtn;
 
         [HarmonyPatch(typeof(UIGame), nameof(UIGame._OnInit))]
@@ -41,7 +54,7 @@ namespace ProjectOrbitalRing.Patches.UI.PlanetFocus
             if (notgas)
             {
                 ProjectOrbitalRing.PlanetFocusWindow.nameText.text = __instance.planet.displayName + " - " + "星球特质".TranslateFromJson();
-                switch (__instance.planet.theme) {
+                switch (PlanetThemeUtils.GetVanillaThemeId(__instance.planet)) {
                     case 1:
                         ProjectOrbitalRing.PlanetFocusWindow.FocusId = 6526;
                         break;
@@ -71,6 +84,7 @@ namespace ProjectOrbitalRing.Patches.UI.PlanetFocus
                         break;
                     default:
                         ProjectOrbitalRing.PlanetFocusWindow.FocusId = 6534;
+                        LogDefaultFocus(__instance.planet);
                         break;
                 }
 

--- a/src/Utils/PlanetThemeUtils.cs
+++ b/src/Utils/PlanetThemeUtils.cs
@@ -1,0 +1,136 @@
+using System.Collections.Generic;
+using BepInEx.Bootstrap;
+using GalacticScale;
+
+namespace ProjectOrbitalRing.Utils
+{
+    internal static class PlanetThemeUtils
+    {
+        private const string GS2_GUID = "dsp.galactic-scale.2";
+
+        private static readonly Dictionary<string, int> ThemeNameToVanillaThemeId = new Dictionary<string, int>
+        {
+            ["Mediterranean"] = 1,
+            ["AshenGelisol"] = 1,
+            ["GasGiant"] = 2,
+            ["GasGiant2"] = 3,
+            ["GasGiant3"] = 2,
+            ["GasGiant4"] = 3,
+            ["IceGiant"] = 4,
+            ["IceGiant2"] = 5,
+            ["IceGiant3"] = 4,
+            ["IceGiant4"] = 5,
+            ["AridDesert"] = 6,
+            ["AridDesert2"] = 6,
+            ["OceanicJungle"] = 8,
+            ["Lava"] = 9,
+            ["IceGelisol"] = 10,
+            ["IceGelisol2"] = 10,
+            ["IceGelisol3"] = 10,
+            ["Barren"] = 11,
+            ["Gobi"] = 12,
+            ["VolcanicAsh"] = 13,
+            ["RedStone"] = 14,
+            ["Prairie"] = 15,
+            ["OceanWorld"] = 16,
+            ["SaltLake"] = 17,
+            ["Sakura"] = 18,
+            ["Hurricane"] = 19,
+            ["IceLake"] = 20,
+            ["GasGiant5"] = 21,
+            ["Savanna"] = 22,
+            ["CrystalDesert"] = 23,
+            ["FrozenTundra"] = 24,
+            ["PandoraSwamp"] = 25,
+            ["PandoraSwamp2"] = 25,
+        };
+
+        internal static int GetVanillaThemeId(PlanetData planet)
+        {
+            if (planet == null) return 0;
+
+            if (!Chainloader.PluginInfos.ContainsKey(GS2_GUID))
+            {
+                return planet.theme;
+            }
+
+            try
+            {
+                GSPlanet gsPlanet = GS2.GetGSPlanet(planet);
+                if (gsPlanet != null && TryResolveVanillaThemeId(gsPlanet.Theme, out int vanillaThemeId))
+                {
+                    return vanillaThemeId;
+                }
+            }
+            catch
+            {
+                // 防御性兜底，避免 Touhma 版 GS2 未来改变 API 时引发新崩溃
+            }
+
+            return planet.theme;
+        }
+
+        internal static string GetThemeDebugInfo(PlanetData planet)
+        {
+            if (planet == null) return "planet=<null>";
+
+            string gsThemeName = null;
+            string gsBaseName = null;
+            int gsThemeLdbThemeId = -1;
+            string gsError = null;
+
+            if (Chainloader.PluginInfos.ContainsKey(GS2_GUID))
+            {
+                try
+                {
+                    GSPlanet gsPlanet = GS2.GetGSPlanet(planet);
+                    gsThemeName = gsPlanet?.Theme;
+                    GSTheme gsTheme = gsPlanet?.GsTheme;
+                    gsBaseName = gsTheme?.BaseName;
+                    if (gsTheme != null) gsThemeLdbThemeId = gsTheme.LDBThemeId;
+                }
+                catch (System.Exception ex)
+                {
+                    gsError = ex.GetType().Name + ": " + ex.Message;
+                }
+            }
+
+            return $"planetId={planet.id}, displayName={planet.displayName}, planet.theme={planet.theme}, planet.type={planet.type}, gsTheme={gsThemeName ?? "<null>"}, gsBase={gsBaseName ?? "<null>"}, gsTheme.LDBThemeId={gsThemeLdbThemeId}, resolvedVanillaTheme={GetVanillaThemeId(planet)}{(string.IsNullOrEmpty(gsError) ? string.Empty : ", gsError=" + gsError)}";
+        }
+
+        private static bool TryResolveVanillaThemeId(string themeName, out int vanillaThemeId)
+        {
+            return TryResolveVanillaThemeId(themeName, new HashSet<string>(), out vanillaThemeId);
+        }
+
+        private static bool TryResolveVanillaThemeId(string themeName, HashSet<string> visited, out int vanillaThemeId)
+        {
+            vanillaThemeId = 0;
+
+            if (string.IsNullOrEmpty(themeName)) return false;
+            if (!visited.Add(themeName)) return false;
+
+            if (ThemeNameToVanillaThemeId.TryGetValue(themeName, out vanillaThemeId))
+            {
+                return true;
+            }
+
+            if (!GSSettings.ThemeLibrary.ContainsKey(themeName)) return false;
+
+            GSTheme theme = GSSettings.ThemeLibrary[themeName];
+            if (theme == null) return false;
+
+            if (ThemeNameToVanillaThemeId.TryGetValue(theme.Name, out vanillaThemeId))
+            {
+                return true;
+            }
+
+            if (!string.IsNullOrEmpty(theme.BaseName))
+            {
+                return TryResolveVanillaThemeId(theme.BaseName, visited, out vanillaThemeId);
+            }
+
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
## 这个 PR 做了什么

修复星环 Mod 在装了 Touhma 版 [Galactic Scale 2](https://github.com/Touhma/DSP_Galactic_Scale)（`dsp.galactic-scale.2`）的 DSP 0.10.34 环境下遇到的两个问题。

改动原则：**不动业务逻辑，只加兼容层**。没装 GS2 时，所有改动都会退化到原版行为，不产生任何影响。

---

## 问题一：启动时 NullReferenceException 导致 InstallationCheckPlugin 崩溃

### 现象

装了 Touhma 版 GS2 后启动游戏，日志里报：

```
NullReferenceException: Null method for ProjectOrbitalRing.Compatibility.dsp.galactic-scale.2
```

`InstallationCheckPlugin.Awake` 直接崩掉，主菜单提示框、HarmonyLogListener、BepInEx 版本检查等功能全部失效。

### 原因

Touhma 版 GS2 源码里，`PatchOnUIPlanetDetail.OnPlanetDataSet7Prefix` 这个方法被整段注释掉了（`OnPlanetDataSet.cs` 第 158-730 行），编译出来的 DLL 里根本没有这个方法。

星环的 `src/Compatibility/GalacticScale.cs` 在 `Awake()` 里用 `AccessTools.Method(...)` 反射拿这个方法，拿到的是 `null`，然后直接传给了 `HarmonyPatch.Patch(null, ...)`，于是就炸了。`OnStarDataSet2` 那一处也有同样的风险，只是当前版本里方法还在，暂时没触发。

### 改动

**文件：`src/Compatibility/GalacticScale.cs`**

在 `Awake()` 里给 `OnPlanetDataSet7Prefix` 和 `OnStarDataSet2` 两个 `MethodInfo` 各加了 `if (... != null)` 判断，包住后面的 `HarmonyPatch.Patch` 调用。方法不存在就跳过，不崩溃。以后 GS2 如果恢复了这个方法，反射会自动拿到，钩子会自动生效，不需要再改代码。

---

## 问题二：GS2 星系里，低温工厂、电磁轨道弹射器等建筑放不下去，星球特质按钮也走错分支

### 现象

在 GS2 生成的星系里：

- 低温工厂在冰系星球上放不下去
- 电磁轨道弹射器在贫瘠荒漠上放不下去
- 冰系星球的低温工厂能耗折扣不生效
- 贫瘠荒漠的熔炉增产不生效
- 水世界的自动补水不生效
- 砍树挖石头的掉落物不对
- 星球特质按钮分配错误

### 原因

星环 Mod 里有 14 处代码把 `planet.theme` 和原版 theme ID（7、10、11、16、18、20、24 等）做硬编码比较。

GS2 往 `LDB.themes` 注入自定义主题时会重新分配 theme ID，`planet.theme` 的值不再等于原版的那些固定数字。所以上面所有 `planet.theme == X` 的判断在 GS2 星系里全部失效。

### 改动思路

新增一个工具函数 `PlanetThemeUtils.GetVanillaThemeId(PlanetData)`，把 `planet.theme` 的读取统一替换为"解析为原版 theme ID"：

1. 没装 GS2：直接返回 `planet.theme`，行为和改动前完全一致。
2. 装了 GS2：通过 `GS2.GetGSPlanet(planet).Theme` 拿到主题名字符串，查一张静态映射表得到原版 theme ID。
3. 如果主题名不在映射表里（比如 GS2 的衍生主题），沿 `GSTheme.BaseName` 递归向上找，直到命中基础主题。

**不用 `GSTheme.LDBThemeId`**，因为这个字段在运行时会被 GS2 的 `AddToThemeProtoSet()` 改写成动态分配的新 ID，已经不是原版 ID 了。

### 具体改了哪些文件

#### 新增文件

**`src/Utils/PlanetThemeUtils.cs`**

包含：
- `GetVanillaThemeId(PlanetData)` - 核心解析函数
- `TryResolveVanillaThemeId(string, ...)` - 递归回溯衍生主题
- `GetThemeDebugInfo(PlanetData)` - 调试用，保留备用，运行时不调用
- `ThemeNameToVanillaThemeId` - 30+ 个 GS2 主题名到原版 theme ID 的映射表

#### csproj 改动

**`ProjectOrbitalRing.csproj`**

在 `<Compile Include="src\Utils\MutliPlayerPacket.cs" />` 之后加了一行：

```xml
<Compile Include="src\Utils\PlanetThemeUtils.cs" />
```

#### 替换了 14 处 `planet.theme` 读取

| 文件 | 改动位置 | 说明 |
|------|---------|------|
| `src/Patches/Logic/OrbitalRing/OrbitalBuild.cs` | 第 311、317、456、463 行 | 电磁轨道弹射器和低温工厂的放置检查，`DeterminePreviewsPatch` 和 `CheckBuildConditionsPrePatch` 各一次 |
| `src/Patches/Logic/Module/AssemblerModule.cs` | 第 401 行 | 冰系星球低温工厂能耗折扣 |
| `src/Patches/Logic/PlanetFocus/MoonPatch.cs` | 第 156、196 行 | 贫瘠荒漠熔炉产物自带增产 |
| `src/Patches/Logic/PlanetFocus/WaterWorldPatch.cs` | 第 14 行 | 水世界自动补水 |
| `src/Patches/Logic/FelTreeObjects.cs` | 第 114、126、161、167、172 行 | 砍树挖石头掉落物的 theme 分支 |
| `src/Patches/UI/PlanetFocus/UIPlanetDetailExpand.cs` | 第 44 行 | `switch (planet.theme)` 改为 `switch (PlanetThemeUtils.GetVanillaThemeId(planet))` |

#### 不需要改的地方

- `src/Patches/Logic/OverWriteBirthGalaxy.cs` 第 594 行 `planet.theme = 11` 是赋值不是读取，不受影响。
- `src/Compatibility/GalacticScale.cs` 里对 `GSTheme.LDBThemeId` 的判断是直接操作 GS2 主题对象，语义不同，不在这次修改范围内。

---

## 验证结果

- 问题一：日志中 NRE 消失，`InstallationCheckPlugin` 正常加载。
- 问题二：
  - 低温工厂在 GS2 的 `IceGelisol` / `FrozenTundra` / `IceLake` 上都能正常放置。
  - 电磁轨道弹射器在 GS2 的 `Barren` 上能正常放置。
  - 星球特质按钮按原版 theme ID 正确分配。走到 `default` 的行星（熔岩、火山灰、暴风星等）在原版 Mod 的 switch 里本来就没有 case，属于设计行为，不是 Bug。

## 没有动的东西

- 原版 Mod 中熔岩、火山灰、暴风星、戈壁、水晶荒漠等 theme 没有分配星球特质，这次不扩充。
- 中子星行星强制设定 `FocusId = 6529` 的行为原样保留。
- 气态行星的特质按钮本来就会被隐藏，保留不动。

---

## 额外建议

建议上游仓库开一个 `dev` 分支用于接收 PR，并给 `main` 分支加上分支保护规则（至少要求 PR review 才能合并）。现在 `main` 是完全开放的，任何人 fork 之后都可以直接向 `main` 提 PR，万一有人提了个有问题的 PR 被不小心合进去就不好了。
