### PR TITLE
修复无GS2环境兼容问题并补全GS2小型主题解析

### DIFF
--- a/src/Utils/PlanetThemeUtils.cs
+++ b/src/Utils/PlanetThemeUtils.cs
@@ -1,6 +1,10 @@
+using System;
+using System.Collections;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Reflection;
+using System.Runtime.CompilerServices;
 using BepInEx.Bootstrap;
-using GalacticScale;
 
 namespace ProjectOrbitalRing.Utils
 {
@@ -45,6 +49,34 @@ namespace ProjectOrbitalRing.Utils
             ["PandoraSwamp2"] = 25,
         };
 
+        private static readonly ConcurrentDictionary<string, int?> ResolvedThemeNameCache = new ConcurrentDictionary<string, int?>();
+        private static readonly ConditionalWeakTable<PlanetData, CachedPlanetThemeValue> CachedPlanetVanillaThemeIds =
+            new ConditionalWeakTable<PlanetData, CachedPlanetThemeValue>();
+        private static readonly object GS2ReflectionLock = new object();
+        private static readonly BindingFlags AnyStatic = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static;
+        private static readonly BindingFlags AnyInstance = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance;
+
+        private static bool GS2ReflectionInitialized;
+        private static bool GS2ReflectionAvailable;
+
+        private static MethodInfo GS2GetGSPlanetMethod;
+        private static MemberInfo GSPlanetThemeMember;
+        private static MemberInfo GSPlanetGsThemeMember;
+        private static MemberInfo GSThemeNameMember;
+        private static MemberInfo GSThemeBaseNameMember;
+        private static MemberInfo GSThemeLdbThemeIdMember;
+        private static MemberInfo GSSettingsThemeLibraryMember;
+
+        private sealed class CachedPlanetThemeValue
+        {
+            internal CachedPlanetThemeValue(int vanillaThemeId)
+            {
+                VanillaThemeId = vanillaThemeId;
+            }
+
+            internal int VanillaThemeId { get; }
+        }
+
         internal static int GetVanillaThemeId(PlanetData planet)
         {
             if (planet == null) return 0;
@@ -54,12 +86,18 @@ namespace ProjectOrbitalRing.Utils
                 return planet.theme;
             }
 
+            if (CachedPlanetVanillaThemeIds.TryGetValue(planet, out CachedPlanetThemeValue cachedPlanetThemeValue))
+            {
+                return cachedPlanetThemeValue.VanillaThemeId;
+            }
+
             try
             {
-                GSPlanet gsPlanet = GS2.GetGSPlanet(planet);
-                if (gsPlanet != null && TryResolveVanillaThemeId(gsPlanet.Theme, out int vanillaThemeId))
+                int? vanillaThemeId = GetVanillaThemeIdFromGS2(planet);
+                if (vanillaThemeId.HasValue)
                 {
-                    return vanillaThemeId;
+                    CachedPlanetVanillaThemeIds.GetValue(planet, _ => new CachedPlanetThemeValue(vanillaThemeId.Value));
+                    return vanillaThemeId.Value;
                 }
             }
             catch
@@ -83,13 +121,9 @@ namespace ProjectOrbitalRing.Utils
             {
                 try
                 {
-                    GSPlanet gsPlanet = GS2.GetGSPlanet(planet);
-                    gsThemeName = gsPlanet?.Theme;
-                    GSTheme gsTheme = gsPlanet?.GsTheme;
-                    gsBaseName = gsTheme?.BaseName;
-                    if (gsTheme != null) gsThemeLdbThemeId = gsTheme.LDBThemeId;
+                    FillThemeDebugInfoFromGS2(planet, out gsThemeName, out gsBaseName, out gsThemeLdbThemeId);
                 }
-                catch (System.Exception ex)
+                catch (Exception ex)
                 {
                     gsError = ex.GetType().Name + ": " + ex.Message;
                 }
@@ -98,12 +132,73 @@ namespace ProjectOrbitalRing.Utils
             return $"planetId={planet.id}, displayName={planet.displayName}, planet.theme={planet.theme}, planet.type={planet.type}, gsTheme={gsThemeName ?? "<null>"}, gsBase={gsBaseName ?? "<null>"}, gsTheme.LDBThemeId={gsThemeLdbThemeId}, resolvedVanillaTheme={GetVanillaThemeId(planet)}{(string.IsNullOrEmpty(gsError) ? string.Empty : ", gsError=" + gsError)}";
         }
 
-        private static bool TryResolveVanillaThemeId(string themeName, out int vanillaThemeId)
+        private static int? GetVanillaThemeIdFromGS2(PlanetData planet)
         {
-            return TryResolveVanillaThemeId(themeName, new HashSet<string>(), out vanillaThemeId);
+            if (!EnsureGS2Reflection()) return null;
+
+            object gsPlanet = InvokeGS2GetGSPlanet(planet);
+            if (gsPlanet == null) return null;
+
+            string themeName = GetMemberValue<string>(gsPlanet, GSPlanetThemeMember);
+            if (TryResolveVanillaThemeIdFromGS2(themeName, out int vanillaThemeId))
+            {
+                return vanillaThemeId;
+            }
+
+            return null;
         }
 
-        private static bool TryResolveVanillaThemeId(string themeName, HashSet<string> visited, out int vanillaThemeId)
+        private static void FillThemeDebugInfoFromGS2(PlanetData planet, out string gsThemeName, out string gsBaseName,
+            out int gsThemeLdbThemeId)
+        {
+            gsThemeName = null;
+            gsBaseName = null;
+            gsThemeLdbThemeId = -1;
+
+            if (!EnsureGS2Reflection()) return;
+
+            object gsPlanet = InvokeGS2GetGSPlanet(planet);
+            if (gsPlanet == null) return;
+
+            gsThemeName = GetMemberValue<string>(gsPlanet, GSPlanetThemeMember);
+
+            object gsTheme = GetMemberValue<object>(gsPlanet, GSPlanetGsThemeMember);
+            if (gsTheme == null) return;
+
+            gsBaseName = GetMemberValue<string>(gsTheme, GSThemeBaseNameMember);
+            int? ldbThemeId = GetMemberValue<int?>(gsTheme, GSThemeLdbThemeIdMember);
+            if (ldbThemeId.HasValue)
+            {
+                gsThemeLdbThemeId = ldbThemeId.Value;
+            }
+        }
+
+        private static bool TryResolveVanillaThemeIdFromGS2(string themeName, out int vanillaThemeId)
+        {
+            vanillaThemeId = 0;
+
+            if (string.IsNullOrEmpty(themeName)) return false;
+
+            if (ResolvedThemeNameCache.TryGetValue(themeName, out int? cachedVanillaThemeId))
+            {
+                if (cachedVanillaThemeId.HasValue)
+                {
+                    vanillaThemeId = cachedVanillaThemeId.Value;
+                    return true;
+                }
+
+                return false;
+            }
+
+            IDictionary themeLibrary = GetGS2ThemeLibrary();
+            bool resolved = TryResolveVanillaThemeIdFromGS2(themeName, new HashSet<string>(), themeLibrary, out vanillaThemeId);
+
+            ResolvedThemeNameCache[themeName] = resolved ? (int?)vanillaThemeId : null;
+            return resolved;
+        }
+
+        private static bool TryResolveVanillaThemeIdFromGS2(string themeName, HashSet<string> visited, IDictionary themeLibrary,
+            out int vanillaThemeId)
         {
             vanillaThemeId = 0;
 
@@ -115,22 +210,191 @@ namespace ProjectOrbitalRing.Utils
                 return true;
             }
 
-            if (!GSSettings.ThemeLibrary.ContainsKey(themeName)) return false;
-
-            GSTheme theme = GSSettings.ThemeLibrary[themeName];
-            if (theme == null) return false;
-
-            if (ThemeNameToVanillaThemeId.TryGetValue(theme.Name, out vanillaThemeId))
+            if (TryResolveSmolThemeIdFromGS2(themeName, visited, themeLibrary, out vanillaThemeId))
             {
                 return true;
             }
 
-            if (!string.IsNullOrEmpty(theme.BaseName))
+            if (themeLibrary == null || !themeLibrary.Contains(themeName)) return false;
+
+            object theme = themeLibrary[themeName];
+            if (theme == null) return false;
+
+            string reflectedThemeName = GetMemberValue<string>(theme, GSThemeNameMember);
+            if (!string.IsNullOrEmpty(reflectedThemeName) &&
+                ThemeNameToVanillaThemeId.TryGetValue(reflectedThemeName, out vanillaThemeId))
             {
-                return TryResolveVanillaThemeId(theme.BaseName, visited, out vanillaThemeId);
+                return true;
+            }
+
+            if (!string.IsNullOrEmpty(reflectedThemeName) &&
+                TryResolveSmolThemeIdFromGS2(reflectedThemeName, visited, themeLibrary, out vanillaThemeId))
+            {
+                return true;
+            }
+
+            string baseName = GetMemberValue<string>(theme, GSThemeBaseNameMember);
+            if (!string.IsNullOrEmpty(baseName))
+            {
+                return TryResolveVanillaThemeIdFromGS2(baseName, visited, themeLibrary, out vanillaThemeId);
             }
 
             return false;
+        }
+
+        private static bool TryResolveSmolThemeIdFromGS2(string themeName, HashSet<string> visited, IDictionary themeLibrary,
+            out int vanillaThemeId)
+        {
+            vanillaThemeId = 0;
+
+            if (string.IsNullOrEmpty(themeName)) return false;
+            if (!themeName.EndsWith("smol", StringComparison.Ordinal)) return false;
+            if (themeName.Length <= 4) return false;
+
+            string trimmedThemeName = themeName.Substring(0, themeName.Length - 4);
+            if (string.IsNullOrEmpty(trimmedThemeName)) return false;
+
+            if (ThemeNameToVanillaThemeId.TryGetValue(trimmedThemeName, out vanillaThemeId))
+            {
+                return true;
+            }
+
+            return TryResolveVanillaThemeIdFromGS2(trimmedThemeName, visited, themeLibrary, out vanillaThemeId);
+        }
+
+        private static IDictionary GetGS2ThemeLibrary()
+        {
+            if (!EnsureGS2Reflection()) return null;
+            return GetStaticMemberValue<object>(GSSettingsThemeLibraryMember) as IDictionary;
+        }
+
+        private static bool EnsureGS2Reflection()
+        {
+            if (GS2ReflectionInitialized) return GS2ReflectionAvailable;
+
+            lock (GS2ReflectionLock)
+            {
+                if (GS2ReflectionInitialized) return GS2ReflectionAvailable;
+
+                GS2ReflectionAvailable = InitializeGS2Reflection();
+                GS2ReflectionInitialized = true;
+                return GS2ReflectionAvailable;
+            }
+        }
+
+        private static bool InitializeGS2Reflection()
+        {
+            if (!Chainloader.PluginInfos.TryGetValue(GS2_GUID, out BepInEx.PluginInfo pluginInfo)) return false;
+
+            Assembly assembly = pluginInfo.Instance.GetType().Assembly;
+            Type gs2Type = assembly.GetType("GalacticScale.GS2");
+            Type gsPlanetType = assembly.GetType("GalacticScale.GSPlanet");
+            Type gsThemeType = assembly.GetType("GalacticScale.GSTheme");
+            Type gsSettingsType = assembly.GetType("GalacticScale.GSSettings");
+
+            if (gs2Type == null || gsPlanetType == null || gsThemeType == null || gsSettingsType == null)
+            {
+                return false;
+            }
+
+            GS2GetGSPlanetMethod = FindStaticMethod(gs2Type, "GetGSPlanet", typeof(PlanetData));
+            GSPlanetThemeMember = FindMember(gsPlanetType, "Theme", false);
+            GSPlanetGsThemeMember = FindMember(gsPlanetType, "GsTheme", false);
+            GSThemeNameMember = FindMember(gsThemeType, "Name", false);
+            GSThemeBaseNameMember = FindMember(gsThemeType, "BaseName", false);
+            GSThemeLdbThemeIdMember = FindMember(gsThemeType, "LDBThemeId", false);
+            GSSettingsThemeLibraryMember = FindMember(gsSettingsType, "ThemeLibrary", true);
+
+            return GS2GetGSPlanetMethod != null &&
+                   GSPlanetThemeMember != null &&
+                   GSPlanetGsThemeMember != null &&
+                   GSThemeNameMember != null &&
+                   GSThemeBaseNameMember != null &&
+                   GSThemeLdbThemeIdMember != null &&
+                   GSSettingsThemeLibraryMember != null;
+        }
+
+        private static MethodInfo FindStaticMethod(Type type, string name, Type parameterType)
+        {
+            foreach (MethodInfo method in type.GetMethods(AnyStatic))
+            {
+                if (method.Name != name) continue;
+
+                ParameterInfo[] parameters = method.GetParameters();
+                if (parameters.Length != 1) continue;
+                if (parameters[0].ParameterType != parameterType) continue;
+
+                return method;
+            }
+
+            return null;
+        }
+
+        private static MemberInfo FindMember(Type type, string name, bool isStatic)
+        {
+            BindingFlags flags = isStatic ? AnyStatic : AnyInstance;
+
+            PropertyInfo property = type.GetProperty(name, flags);
+            if (property != null && property.GetGetMethod(true) != null)
+            {
+                return property;
+            }
+
+            FieldInfo field = type.GetField(name, flags);
+            if (field != null)
+            {
+                return field;
+            }
+
+            return null;
+        }
+
+        private static object InvokeGS2GetGSPlanet(PlanetData planet)
+        {
+            if (GS2GetGSPlanetMethod == null) return null;
+            return GS2GetGSPlanetMethod.Invoke(null, new object[] { planet });
+        }
+
+        private static T GetMemberValue<T>(object instance, MemberInfo member)
+        {
+            if (instance == null || member == null) return default(T);
+
+            object value = null;
+            if (member is PropertyInfo property)
+            {
+                value = property.GetValue(instance, null);
+            }
+            else if (member is FieldInfo field)
+            {
+                value = field.GetValue(instance);
+            }
+
+            if (value == null) return default(T);
+            if (value is T typedValue) return typedValue;
+
+            Type targetType = Nullable.GetUnderlyingType(typeof(T)) ?? typeof(T);
+            return (T)Convert.ChangeType(value, targetType);
+        }
+
+        private static T GetStaticMemberValue<T>(MemberInfo member)
+        {
+            if (member == null) return default(T);
+
+            object value = null;
+            if (member is PropertyInfo property)
+            {
+                value = property.GetValue(null, null);
+            }
+            else if (member is FieldInfo field)
+            {
+                value = field.GetValue(null);
+            }
+
+            if (value == null) return default(T);
+            if (value is T typedValue) return typedValue;
+
+            Type targetType = Nullable.GetUnderlyingType(typeof(T)) ?? typeof(T);
+            return (T)Convert.ChangeType(value, targetType);
         }
     }
 }


### PR DESCRIPTION
## 说明

这个 PR 处理了星环与 Touhma 版 GS2 的两类兼容问题。

### 一、修复未安装 GS2 时的崩溃

PlanetThemeUtils.GetVanillaThemeId 之前在方法体里直接静态引用了 GS2 类型。未安装 GS2 时，运行时会先解析 GalacticScale.dll，导致抛出 System.IO.FileNotFoundException。

这次改为反射加缓存实现。未安装 GS2 时直接返回 planet.theme，不再触发 GalacticScale.dll 加载；安装 GS2 时再通过反射读取主题信息。

### 二、补全 GS2 小型主题的原版 Theme 还原

GS2 会自动生成 *smol 小型主题，例如 Barrensmol。这类主题之前无法还原到原版 Theme ID，导致贫瘠荒漠小型卫星上的 电磁轨道弹射器 建造条件判断失败。

这次在 PlanetThemeUtils 中补了一条 smol 后缀回退规则：

- Barrensmol -> Barren -> 11

这样 GS2 的小型贫瘠荒漠天体也能正确通过原版 Theme 判断。

## 影响范围

这次改动只集中在：

- src/Utils/PlanetThemeUtils.cs

没有改动各个业务调用点。

## 已验证

- 未安装 GS2 时不再因为 GalacticScale.dll 缺失而崩溃
- GS2 中 Barrensmol 等小型贫瘠荒漠天体上，电磁轨道弹射器 已可正常放置
- 水世界 相关功能保持正常
- 低温工厂 相关功能保持正常
- 星球特质 相关功能保持正常